### PR TITLE
Simplify File Logger Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](./example.png)
 
-`ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind.
+`ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. The logger is threadsafe in that only one thread can log at any one moment.
 
 # why another logging library?
 
@@ -58,6 +58,10 @@ LOGF_INFO(fhl->thl, fhl->fd, "this is a %s style info log", "printf");
 LOGF_WARN(fhl->thl, fhl->fd, "this is a %s style warn log", "printf");
 LOGF_ERROR(fhl->thl, fhl->fd, "this is a %s style error log", "printf");
 LOGF_DEBUG(fhl->thl, fhl->fd, "this is a %s style debug log", "printf");
+
+// if you dont want to loger to a file and just stdout, simply set the `fhl->fd` value to 0
+LOG_INFO(fhl->thl, 0, "this will only log to stdout");
+LOGF_INFO(fhl->thl, 0, "this will only log to %s", "stdout");
 
 clear_file_logger(fhl);
 ```

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ clear_thread_logger(thl);
 
 file_logger *fhl = new_file_logger("testfile.log", true);
 
-LOG_INFO(fhl->thl, fhl->file_descriptor, "this is an info log");
-LOG_WARN(fhl->thl, fhl->file_descriptor,"this is a warn log");
-LOG_ERROR(fhl->thl, fhl->file_descriptor, "this is an error log");
-LOG_DEBUG(fhl->thl, fhl->file_descriptor, "this is a debug log");
+LOG_INFO(fhl->thl, fhl->fd, "this is an info log");
+LOG_WARN(fhl->thl, fhl->fd,"this is a warn log");
+LOG_ERROR(fhl->thl, fhl->fd, "this is an error log");
+LOG_DEBUG(fhl->thl, fhl->fd, "this is a debug log");
 
-LOGF_INFO(fhl->thl, fhl->file_descriptor, "this is a %s style info log", "printf");
-LOGF_WARN(fhl->thl, fhl->file_descriptor, "this is a %s style warn log", "printf");
-LOGF_ERROR(fhl->thl, fhl->file_descriptor, "this is a %s style error log", "printf");
-LOGF_DEBUG(fhl->thl, fhl->file_descriptor, "this is a %s style debug log", "printf");
+LOGF_INFO(fhl->thl, fhl->fd, "this is a %s style info log", "printf");
+LOGF_WARN(fhl->thl, fhl->fd, "this is a %s style warn log", "printf");
+LOGF_ERROR(fhl->thl, fhl->fd, "this is a %s style error log", "printf");
+LOGF_DEBUG(fhl->thl, fhl->fd, "this is a %s style debug log", "printf");
 
 clear_file_logger(fhl);
 ```

--- a/include/logger.h
+++ b/include/logger.h
@@ -116,8 +116,8 @@ typedef struct thread_logger {
  *  - enable log rotation
  */
 typedef struct file_logger {
-    thread_logger *thl;
-    int file_descriptor;
+    thread_logger *thl; /*! @brief the underlying threadsafe logger used for sycnhronization and the actual logging */
+    int fd; /*! @brief the file descriptor used for sending log information to */
 } file_logger;
 
 /*! @brief returns a new thread safe logger

--- a/src/logger.c
+++ b/src/logger.c
@@ -81,7 +81,7 @@ file_logger *new_file_logger(char *output_file, bool with_debug) {
         printf("failed to run posix open function\n");
         return NULL;
     }
-    fhl->file_descriptor = file_descriptor;
+    fhl->fd = file_descriptor;
     fhl->thl = thl;
     return fhl;
 }
@@ -252,7 +252,7 @@ void clear_thread_logger(thread_logger *thl) {
 }
 
 void clear_file_logger(file_logger *fhl) {
-    close(fhl->file_descriptor);
+    close(fhl->fd);
     clear_thread_logger(fhl->thl);
     free(fhl);
 }

--- a/tests/logger_test.c
+++ b/tests/logger_test.c
@@ -210,6 +210,10 @@ void test_demo_log_file(void **state) {
     LOGF_ERROR(fhl->thl, fhl->fd, "this is a %s style error log", "printf");
     LOGF_DEBUG(fhl->thl, fhl->fd, "this is a %s style debug log", "printf");
 
+    // if you dont want to loger to a file and just stdout, simply set the `fhl->fd` value to 0
+    LOG_INFO(fhl->thl, 0, "this will only log to stdout");
+    LOGF_INFO(fhl->thl, 0, "this will only log to %s", "stdout");
+
     clear_file_logger(fhl);
 }
 

--- a/tests/logger_test.c
+++ b/tests/logger_test.c
@@ -29,17 +29,17 @@ void *test_thread_log(void *data) {
 
 void *test_file_log(void *data) {
     file_logger *fhl = (file_logger *)data;
-    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an info log", LOG_LEVELS_INFO, __FILENAME__, __LINE__);
-    fhl->thl->logf(fhl->thl, fhl->file_descriptor, LOG_LEVELS_INFO, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
+    fhl->thl->log(fhl->thl, fhl->fd, "this is an info log", LOG_LEVELS_INFO, __FILENAME__, __LINE__);
+    fhl->thl->logf(fhl->thl, fhl->fd, LOG_LEVELS_INFO, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
 
-    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a warn log", LOG_LEVELS_WARN, __FILENAME__, __LINE__);
-    fhl->thl->logf(fhl->thl, fhl->file_descriptor, LOG_LEVELS_WARN, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
+    fhl->thl->log(fhl->thl, fhl->fd, "this is a warn log", LOG_LEVELS_WARN, __FILENAME__, __LINE__);
+    fhl->thl->logf(fhl->thl, fhl->fd, LOG_LEVELS_WARN, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
 
-    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an error log", LOG_LEVELS_ERROR, __FILENAME__, __LINE__);
-    fhl->thl->logf(fhl->thl, fhl->file_descriptor, LOG_LEVELS_ERROR, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
+    fhl->thl->log(fhl->thl, fhl->fd, "this is an error log", LOG_LEVELS_ERROR, __FILENAME__, __LINE__);
+    fhl->thl->logf(fhl->thl, fhl->fd, LOG_LEVELS_ERROR, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
     
-    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a debug log", LOG_LEVELS_DEBUG, __FILENAME__, __LINE__);
-    fhl->thl->logf(fhl->thl, fhl->file_descriptor, LOG_LEVELS_DEBUG, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
+    fhl->thl->log(fhl->thl, fhl->fd, "this is a debug log", LOG_LEVELS_DEBUG, __FILENAME__, __LINE__);
+    fhl->thl->logf(fhl->thl, fhl->fd, LOG_LEVELS_DEBUG, __FILENAME__, __LINE__, "%s\t%s", "one", "two");
     // commenting this out seems to get rid of memleaks reported by valgrind
     // pthread_exit(NULL);
     return NULL;
@@ -75,10 +75,10 @@ void test_file_logger(void **state) {
     for (int i = 0; i < 2; i++) {
         file_logger *fhl = new_file_logger("file_logger_test.log", args[i]);
         assert(fhl != NULL);
-        fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an info log", LOG_LEVELS_INFO, __FILENAME__, __LINE__);
-        fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a warn log", LOG_LEVELS_WARN, __FILENAME__, __LINE__);
-        fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an error log", LOG_LEVELS_ERROR, __FILENAME__, __LINE__);
-        fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a debug log", LOG_LEVELS_DEBUG, __FILENAME__, __LINE__);
+        fhl->thl->log(fhl->thl, fhl->fd, "this is an info log", LOG_LEVELS_INFO, __FILENAME__, __LINE__);
+        fhl->thl->log(fhl->thl, fhl->fd, "this is a warn log", LOG_LEVELS_WARN, __FILENAME__, __LINE__);
+        fhl->thl->log(fhl->thl, fhl->fd, "this is an error log", LOG_LEVELS_ERROR, __FILENAME__, __LINE__);
+        fhl->thl->log(fhl->thl, fhl->fd, "this is a debug log", LOG_LEVELS_DEBUG, __FILENAME__, __LINE__);
         pthread_t threads[4];
         pthread_attr_t attrs[4];
         for (int i = 0; i < 4; i++) {
@@ -201,14 +201,14 @@ void test_demo_log_thread(void **state) {
 
 void test_demo_log_file(void **state) {
     file_logger *fhl = new_file_logger("testfile.log", true);
-    LOG_INFO(fhl->thl, fhl->file_descriptor, "this is an info log");
-    LOG_WARN(fhl->thl, fhl->file_descriptor,"this is a warn log");
-    LOG_ERROR(fhl->thl, fhl->file_descriptor, "this is an error log");
-    LOG_DEBUG(fhl->thl, fhl->file_descriptor, "this is a debug log");
-    LOGF_INFO(fhl->thl, fhl->file_descriptor, "this is a %s style info log", "printf");
-    LOGF_WARN(fhl->thl, fhl->file_descriptor, "this is a %s style warn log", "printf");
-    LOGF_ERROR(fhl->thl, fhl->file_descriptor, "this is a %s style error log", "printf");
-    LOGF_DEBUG(fhl->thl, fhl->file_descriptor, "this is a %s style debug log", "printf");
+    LOG_INFO(fhl->thl, fhl->fd, "this is an info log");
+    LOG_WARN(fhl->thl, fhl->fd,"this is a warn log");
+    LOG_ERROR(fhl->thl, fhl->fd, "this is an error log");
+    LOG_DEBUG(fhl->thl, fhl->fd, "this is a debug log");
+    LOGF_INFO(fhl->thl, fhl->fd, "this is a %s style info log", "printf");
+    LOGF_WARN(fhl->thl, fhl->fd, "this is a %s style warn log", "printf");
+    LOGF_ERROR(fhl->thl, fhl->fd, "this is a %s style error log", "printf");
+    LOGF_DEBUG(fhl->thl, fhl->fd, "this is a %s style debug log", "printf");
 
     clear_file_logger(fhl);
 }


### PR DESCRIPTION
This changes the `file_descriptor` member name of the `file_logger` type to `fd` to reduce the typing required to make file logs