### PR TITLE
Codebase Cleanup And Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 `ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. 
 
-If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice even when logging from multiple threads there is very little contention.
+If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice even when logging from multiple threads there is very little contention.  On average the logger consumed roughly 4KB of memory at any one time, however during initialization the memory consumed peaks at around 7KB.
 
-On average the logger consumed roughly 4KB of memory at any one time, however during initialization the memory consumed peaks at around 7KB.
+**Please be aware that after calling `clear_thread_logger` or `clear_file_logger` using the logger results in undefined behavior, likely a panic causing the program to exit. Having one or more threads initiate a log invocation while concurrently calling `clear_thread_logger` or `clear_file_logger` results in undefined behavior. When clearing the logger you must be certain no other threads will attempt to use the logger.
 
 # why another logging library?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. 
 
-If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice even when logging from multiple threads there is very little contention.  On average the logger consumed roughly 4KB of memory at any one time, however during initialization the memory consumed peaks at around 7KB.
+If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice even when logging from multiple threads there is very little contention, and all memory allocations happen outside of mutex locks to ensure that threads aren't blocked on memory allocations. On average the logger consumed roughly 4KB of memory at any one time, however during initialization the memory consumed peaks at around 7KB.
 
 **Please be aware that after calling `clear_thread_logger` or `clear_file_logger` using the logger results in undefined behavior, likely a panic causing the program to exit. Having one or more threads initiate a log invocation while concurrently calling `clear_thread_logger` or `clear_file_logger` results in undefined behavior. When clearing the logger you must be certain no other threads will attempt to use the logger.
 

--- a/src/colors.c
+++ b/src/colors.c
@@ -20,6 +20,7 @@
 /*! @brief returns an ansi color string to be used with printf
  */
 char *get_ansi_color_scheme(COLORS color) {
+
     switch (color) {
         case COLORS_RED:
             return ANSI_COLOR_RED;
@@ -49,17 +50,21 @@ char *get_ansi_color_scheme(COLORS color) {
  * @note you must free up the allocate memory for the returned vlaue
  */
 char *format_colored(COLORS color, char *message) {
+
     char *pcolor = get_ansi_color_scheme(color);
     if (pcolor == NULL) {
         return NULL;
     }
+
     char *formatted = malloc(sizeof(message) + sizeof(pcolor));
     if (formatted == NULL) {
         printf("failed to format colored string\n");
         return NULL;
     }
+
     strcat(formatted, pcolor);
     strcat(formatted, message);
+
     return formatted;
 }
 
@@ -75,30 +80,37 @@ void print_colored(COLORS color, char *message) {
  * @return Failure: 1
  */
 int write_colored(COLORS color, int file_descriptor, char *message) {
+
     char *pcolor = get_ansi_color_scheme(color);
     if (pcolor == NULL) {
         return -1;
     }
+
     char *reset = get_ansi_color_scheme(COLORS_RESET);
     if (reset == NULL) {
         return -1;
     }
-    // 2 for \n
+
     char *write_message =
-        calloc(1, strlen(pcolor) + strlen(reset) + strlen(message) + 2);
+        calloc(1, strlen(pcolor) + strlen(reset) + strlen(message) + 2); // 2 for \n
     if (write_message == NULL) {
         printf("failed to calloc write_message\n");
         return -1;
     }
+
     strcat(write_message, pcolor);
     strcat(write_message, message);
     strcat(write_message, reset);
     strcat(write_message, "\n");
+
     int response = write(file_descriptor, write_message, strlen(write_message));
+
     free(write_message);
+
     if (response == -1) {
         printf("failed to write colored message\n");
         return response;
     }
+
     return 0;
 }

--- a/src/logger.c
+++ b/src/logger.c
@@ -302,6 +302,8 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
  * @param thl the thread_logger instance to free memory for
  */
 void clear_thread_logger(thread_logger *thl) {
+    pthread_mutex_lock(&thl->mutex); // lock before destroying
+    pthread_mutex_destroy(&thl->mutex);
     free(thl);
 }
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -201,13 +201,13 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
  * @param message the actuall message to log
  */
 void info_log(thread_logger *thl, int file_descriptor, char *message) {
-    thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(1, strlen(message) + strlen("[info - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc info_log msg");
         return;
     }
+    thl->lock(&thl->mutex);
     strcat(msg, "[info - ");
     strcat(msg, message);
     if (file_descriptor != 0) {
@@ -225,13 +225,13 @@ void info_log(thread_logger *thl, int file_descriptor, char *message) {
  * @param message the actuall message to log
  */
 void warn_log(thread_logger *thl, int file_descriptor, char *message) {
-    thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(1, strlen(message) + strlen("[warn - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc warn_log msg");
         return;
     }
+    thl->lock(&thl->mutex);
     strcat(msg, "[warn - ");
     strcat(msg, message);
     if (file_descriptor != 0) {
@@ -253,13 +253,13 @@ void warn_log(thread_logger *thl, int file_descriptor, char *message) {
  * @param message the actuall message to log
  */
 void error_log(thread_logger *thl, int file_descriptor, char *message) {
-    thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(1, strlen(message) + strlen("[error - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc error_log msg");
         return;
     }
+    thl->lock(&thl->mutex);
     strcat(msg, "[error - ");
     strcat(msg, message);
     if (file_descriptor != 0) {
@@ -281,14 +281,13 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
     if (thl->debug == false) {
         return;
     }
-
-    thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(1, strlen(message) + strlen("[debug - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc debug_log msg");
         return;
     }
+    thl->lock(&thl->mutex);
     strcat(msg, "[debug - ");
     strcat(msg, message);
     if (file_descriptor != 0) {


### PR DESCRIPTION

* Conduct memory allocations outside of a mutex lock (performance)
* If memory allocation fails, it will be outside of a mutex lock instead of inside a mutex lock (bugfix)
  * This fixes a bug where previously if memory allocation failed, we returned without unlocking the mutex (bugfix)
* Add spacing around segments of business logic within functions (cleanup)
  * I find this makes it easier to read through code and focus on segments of logic (cleanup)
* Update readme to explain memory usage and closure guidelines