### PR TITLE
Remove All Possible Memory Allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 `ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. 
 
-If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice even when logging from multiple threads there is very little contention, and all memory allocations happen outside of mutex locks to ensure that threads aren't blocked on memory allocations. On average the logger consumed roughly 4KB of memory at any one time, however during initialization the memory consumed peaks at around 7KB.
+If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice there is very little lock contention and in all honesty you will probably never have to worry about it.
+
+In terms of memory usage, the only memory allocations conducted by this library are when initializing the logger. During actual logging there is no memory allocations whatsoever, as we use stack allocated variables. In practice logger initialization consumes arounds 7.4 KiB of memory, while regular logger usage general consumes no more than 3 -> 3.4 KiB of memory at any one time.
 
 **Please be aware that after calling `clear_thread_logger` or `clear_file_logger` using the logger results in undefined behavior, likely a panic causing the program to exit. Having one or more threads initiate a log invocation while concurrently calling `clear_thread_logger` or `clear_file_logger` results in undefined behavior. When clearing the logger you must be certain no other threads will attempt to use the logger.**
 

--- a/include/colors.h
+++ b/include/colors.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>
 
-#define COLORS_VERSION '0.0.1'
+#define COLORS_VERSION '0.0.2-rc1'
 
 #define ANSI_COLOR_RED "\x1b[1;31m"
 #define ANSI_COLOR_SOFT_RED "\x1b[1;38;5;210m"

--- a/include/logger.h
+++ b/include/logger.h
@@ -212,6 +212,9 @@ void info_log(thread_logger *thl, int file_descriptor, char *message);
 int write_file_log(int file_descriptor, char *message);
 
 /*! @brief returns a timestamp of format `Jul 06 10:12:20 PM`
- * @note make sure to free up the memory allocated when done
+ * @warning providing an input buffer whose length isnt at least 76 bytes will result
+ * in undefined behavior
+ * @param date_buffer the buffer to write the timestamp into
+ * @param date_buffer_len the size of the buffer
  */
-char *get_time_string();
+void get_time_string(char *date_buffer, size_t date_buffer_len);

--- a/include/logger.h
+++ b/include/logger.h
@@ -31,7 +31,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-#define LOGGER_VERSION '0.0.1'
+#define LOGGER_VERSION '0.0.2-rc1'
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define LOG_INFO(thl, fd, msg) \

--- a/include/logger.h
+++ b/include/logger.h
@@ -118,9 +118,9 @@ typedef struct thread_logger {
  *  - enable log rotation
  */
 typedef struct file_logger {
+    int fd; /*! @brief the file descriptor used for sending log information to */
     thread_logger *thl; /*! @brief the underlying threadsafe logger used for
                            sycnhronization and the actual logging */
-    int fd; /*! @brief the file descriptor used for sending log information to */
 } file_logger;
 
 /*! @brief returns a new thread safe logger

--- a/include/logger.h
+++ b/include/logger.h
@@ -33,21 +33,97 @@
 
 #define LOGGER_VERSION '0.0.2-rc1'
 
+/*!
+ * @brief strips leading path from __FILE__
+ */
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+
+/*!
+ * @brief used to emit a standard INFO log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ */
 #define LOG_INFO(thl, fd, msg) \
     thl->log(thl, fd, msg, LOG_LEVELS_INFO, __FILENAME__, __LINE__);
+
+/*!
+ * @brief used to emit a standard WARN log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ */
 #define LOG_WARN(thl, fd, msg) \
     thl->log(thl, fd, msg, LOG_LEVELS_WARN, __FILENAME__, __LINE__);
+
+/*!
+ * @brief used to emit a standard ERROR log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ */
 #define LOG_ERROR(thl, fd, msg) \
     thl->log(thl, fd, msg, LOG_LEVELS_ERROR, __FILENAME__, __LINE__);
+
+/*!
+ * @brief used to emit a standard DEBUG log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ * @note if logger is created without debug enabled, this is a noop
+ */
 #define LOG_DEBUG(thl, fd, msg) \
     thl->log(thl, fd, msg, LOG_LEVELS_DEBUG, __FILENAME__, __LINE__);
+
+/*!
+ * @brief used to emit a printf INFO log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ * @param msg the printf styled message to format
+ * @param ... the arguments to use for formatting
+ */
 #define LOGF_INFO(thl, fd, msg, ...) \
     thl->logf(thl, fd, LOG_LEVELS_INFO, __FILENAME__, __LINE__, msg, __VA_ARGS__);
+
+/*!
+ * @brief used to emit a printf WARN log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ * @param msg the printf styled message to format
+ * @param ... the arguments to use for formatting
+ */
 #define LOGF_WARN(thl, fd, msg, ...) \
     thl->logf(thl, fd, LOG_LEVELS_WARN, __FILENAME__, __LINE__, msg, __VA_ARGS__);
+
+/*!
+ * @brief used to emit a printf ERROR log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the actual message to log
+ * @param msg the printf styled message to format
+ * @param ... the arguments to use for formatting
+ */
 #define LOGF_ERROR(thl, fd, msg, ...) \
     thl->logf(thl, fd, LOG_LEVELS_ERROR, __FILENAME__, __LINE__, msg, __VA_ARGS__);
+
+/*!
+ * @brief used to emit a printf DEBUG log
+ * @param thl an instance of thread_logger, passing anything other than an
+ * initialized thread_logger will result in undefined benhavior
+ * @param fd the file descriptor to log to, set to 0 if you just want stdout logging
+ * @param msg the printf styled message to format
+ * @param ... the arguments to use for formatting
+ * @note if logger is created without debug enabled, this is a noop
+ */
 #define LOGF_DEBUG(thl, fd, msg, ...) \
     thl->logf(thl, fd, LOG_LEVELS_DEBUG, __FILENAME__, __LINE__, msg, __VA_ARGS__);
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -107,11 +107,8 @@ file_logger *new_file_logger(char *output_file, bool with_debug) {
  */
 int write_file_log(int file_descriptor, char *message) {
 
-    char *msg = calloc(1, strlen(message) + 2); // 2 for \n
-    if (msg == NULL) {
-        printf("failed to calloc msg\n");
-        return -1;
-    }
+    char msg[strlen(message) + 2]; // 2 for \n
+    memset(msg, 0, sizeof(msg));
 
     strcat(msg, message);
     strcat(msg, "\n");
@@ -126,8 +123,6 @@ int write_file_log(int file_descriptor, char *message) {
         // number of bytes written
         response = 0;
     }
-
-    free(msg);
 
     return response;
 }
@@ -216,12 +211,10 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
  */
 void info_log(thread_logger *thl, int file_descriptor, char *message) {
 
-    char *msg = calloc(1, strlen(message) + strlen("[info - ") +
-                              2); // 2, 1 for null terminator and 1 for space after ]
-    if (msg == NULL) {
-        printf("failed to calloc info_log msg");
-        return;
-    }
+    // 2, 1 for null terminator and 1 for space after ]
+    size_t msg_size = strlen(message) + strlen("[info - ") + 2;
+    char msg[msg_size];
+    memset(msg, 0, sizeof(msg));
 
     thl->lock(&thl->mutex);
 
@@ -235,8 +228,6 @@ void info_log(thread_logger *thl, int file_descriptor, char *message) {
     print_colored(COLORS_GREEN, msg);
 
     thl->unlock(&thl->mutex);
-
-    free(msg);
 }
 
 /*! @brief logs a warned styled message - called by log_fn
@@ -247,12 +238,10 @@ void info_log(thread_logger *thl, int file_descriptor, char *message) {
  */
 void warn_log(thread_logger *thl, int file_descriptor, char *message) {
 
-    char *msg = calloc(1, strlen(message) + strlen("[warn - ") +
-                              2); // 2, 1 for null terminator and 1 for space after ]
-    if (msg == NULL) {
-        printf("failed to calloc warn_log msg");
-        return;
-    }
+    // 2, 1 for null terminator and 1 for space after ]
+    size_t msg_size = strlen(message) + strlen("[warn - ") + 2;
+    char msg[msg_size];
+    memset(msg, 0, sizeof(msg));
 
     thl->lock(&thl->mutex);
 
@@ -266,8 +255,6 @@ void warn_log(thread_logger *thl, int file_descriptor, char *message) {
     print_colored(COLORS_YELLOW, msg);
 
     thl->unlock(&thl->mutex);
-
-    free(msg);
 }
 
 /*! @brief logs an error styled message - called by log_fn
@@ -278,12 +265,10 @@ void warn_log(thread_logger *thl, int file_descriptor, char *message) {
  */
 void error_log(thread_logger *thl, int file_descriptor, char *message) {
 
-    char *msg = calloc(1, strlen(message) + strlen("[error - ") +
-                              2); // 2, 1 for null terminator and 1 for space after ]
-    if (msg == NULL) {
-        printf("failed to calloc error_log msg");
-        return;
-    }
+    // 2, 1 for null terminator and 1 for space after ]
+    size_t msg_size = strlen(message) + strlen("[error - ") + 2;
+    char msg[msg_size];
+    memset(msg, 0, sizeof(msg));
 
     thl->lock(&thl->mutex);
 
@@ -297,8 +282,6 @@ void error_log(thread_logger *thl, int file_descriptor, char *message) {
     print_colored(COLORS_RED, msg);
 
     thl->unlock(&thl->mutex);
-
-    free(msg);
 }
 
 /*! @brief logs a debug styled message - called by log_fn
@@ -313,12 +296,10 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
         return;
     }
 
-    char *msg = calloc(1, strlen(message) + strlen("[debug - ") +
-                              2); // 2, 1 for null terminator and 1 for space after ]
-    if (msg == NULL) {
-        printf("failed to calloc debug_log msg");
-        return;
-    }
+    // 2, 1 for null terminator and 1 for space after ]
+    size_t msg_size = strlen(message) + strlen("[debug - ") + 2;
+    char msg[msg_size];
+    memset(msg, 0, sizeof(msg));
 
     thl->lock(&thl->mutex);
 
@@ -332,8 +313,6 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
     print_colored(COLORS_SOFT_RED, msg);
 
     thl->unlock(&thl->mutex);
-
-    free(msg);
 }
 
 /*! @brief free resources for the threaded logger

--- a/src/logger.c
+++ b/src/logger.c
@@ -164,11 +164,12 @@ void logf_func(thread_logger *thl, int file_descriptor, LOG_LEVELS level, char *
 void log_func(thread_logger *thl, int file_descriptor, char *message,
               LOG_LEVELS level, char *file, int line) {
 
-    char *time_str = get_time_string();
-    if (time_str == NULL) {
-        // dont printf log as get_time_str does that
-        return;
-    }
+    char time_str[76];
+    memset(time_str, 0, sizeof(time_str));
+
+    get_time_string(time_str, 76);
+
+    printf("time debug: %s\n", time_str);
 
     char location_info[strlen(file) + sizeof(line) + 4];
     memset(location_info, 0, sizeof(location_info));
@@ -199,8 +200,6 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
             debug_log(thl, file_descriptor, date_msg);
             break;
     }
-
-    free(time_str);
 }
 
 /*! @brief logs an info styled message - called by log_fn
@@ -337,22 +336,13 @@ void clear_file_logger(file_logger *fhl) {
 }
 
 /*! @brief returns a timestamp of format `Jul 06 10:12:20 PM`
- * @note make sure to free up the memory allocated when done
+ * @warning providing an input buffer whose length isnt at least 76 bytes will result
+ * in undefined behavior
+ * @param date_buffer the buffer to write the timestamp into
+ * @param date_buffer_len the size of the buffer
  */
-char *get_time_string() {
+void get_time_string(char *date_buffer, size_t date_buffer_len) {
 
-    char date[75];
-
-    strftime(date, sizeof date, "%b %d %r", localtime(&(time_t){time(NULL)}));
-
-    char *msg = calloc(1, sizeof(date) + 1);
-    if (msg == NULL) {
-        printf("failed to calloc get_time_string\n");
-        return NULL;
-    }
-
-    strcat(msg, "");
-    strcat(msg, date);
-
-    return msg;
+    strftime(date_buffer, date_buffer_len, "%b %d %r",
+             localtime(&(time_t){time(NULL)}));
 }


### PR DESCRIPTION
* Increments version number to v0.0.2-rc1
* Removes all logger memory allocations except for during initialization
* Adds comments for the logger macros
* Appears to reduce active logger memory consumption by 0.6 -> 1 KiB