### PR TITLE
Enables Use In C++ Codebases

### DIFF
--- a/include/colors.h
+++ b/include/colors.h
@@ -23,6 +23,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define COLORS_VERSION '0.0.2-rc1'
 
 #define ANSI_COLOR_RED "\x1b[1;31m"
@@ -71,3 +75,7 @@ void print_colored(COLORS color, char *message);
  * @return Failure: 1
  */
 int write_colored(COLORS color, int file_descriptor, char *message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -31,6 +31,10 @@
 #include <stdbool.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LOGGER_VERSION '0.0.2-rc1'
 
 /*!
@@ -294,3 +298,7 @@ int write_file_log(int file_descriptor, char *message);
  * @param date_buffer_len the size of the buffer
  */
 void get_time_string(char *date_buffer, size_t date_buffer_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/colors.c
+++ b/src/colors.c
@@ -17,6 +17,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*! @brief returns an ansi color string to be used with printf
  */
 char *get_ansi_color_scheme(COLORS color) {
@@ -114,3 +118,7 @@ int write_colored(COLORS color, int file_descriptor, char *message) {
 
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/logger.c
+++ b/src/logger.c
@@ -35,6 +35,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*! @brief returns a new thread safe logger
  * if with_debug is false, then all debug_log calls will be ignored
  * @param with_debug whether to enable debug logging, if false debug log calls will
@@ -346,3 +350,7 @@ void get_time_string(char *date_buffer, size_t date_buffer_len) {
     strftime(date_buffer, date_buffer_len, "%b %d %r",
              localtime(&(time_t){time(NULL)}));
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adds `extern "C"` {}` to source and header files allowing use in C++ codebases