### PR TITLE
C++ Usage Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.0.3 (wip)
+
+* Fixes issues with usage in C++ code [#22](https://github.com/bonedaddy/ulog/pull/22)
+* Remove colored write allocation [#21](https://github.com/bonedaddy/ulog/pull/21)
+
 # v0.0.2
 
 * Enables use in C++ codebases [#19](https://github.com/bonedaddy/ulog/pull/19)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #####################
 
 cmake_minimum_required(VERSION 3.0)
-project(libcp2p LANGUAGES C)
+project(libcp2p LANGUAGES C CXX)
 set(CMAKE_C_COMPILER /usr/bin/gcc)
 
 
@@ -11,12 +11,14 @@ set(CMAKE_C_COMPILER /usr/bin/gcc)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     # -g indicates to include debug symbols
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -g)
+    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -g)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Analyze")
     # override gcc compiler to v10 for static analysis
     set(CMAKE_C_COMPILER /usr/bin/gcc-10)
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -g -fanalyzer)
+    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -g -fanalyzer)
     message(STATUS "enabling static analysis")
 endif()
 
@@ -24,6 +26,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "CI")
     set(CMAKE_BUILD_TYPE "Release")
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -I/usr/local/lib)
+    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -I/usr/local/lib)
     # override the previous C compiler choice
     set(CMAKE_C_COMPILER /usr/bin/gcc-9)
 endif()
@@ -33,6 +36,8 @@ endif()
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic)
+    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic)
+
 endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,14 @@ set(CMAKE_C_COMPILER /usr/bin/gcc)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     # -g indicates to include debug symbols
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -g)
-    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -g)
+    list(APPEND cxx-flags -std=c++2a -Wall -Wextra -Werror -pedantic -g)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Analyze")
     # override gcc compiler to v10 for static analysis
     set(CMAKE_C_COMPILER /usr/bin/gcc-10)
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -g -fanalyzer)
-    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -g -fanalyzer)
+    list(APPEND cxx-flags -std=c++2a -Wall -Wextra -Werror -pedantic -g -fanalyzer)
     message(STATUS "enabling static analysis")
 endif()
 
@@ -26,7 +26,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "CI")
     set(CMAKE_BUILD_TYPE "Release")
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic -I/usr/local/lib)
-    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic -I/usr/local/lib)
+    list(APPEND cxx-flags -std=c++2a -Wall -Wextra -Werror -pedantic -I/usr/local/lib)
     # override the previous C compiler choice
     set(CMAKE_C_COMPILER /usr/bin/gcc-9)
 endif()
@@ -36,7 +36,7 @@ endif()
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
     list(APPEND flags -std=c17 -Wall -Wextra -Werror -pedantic)
-    list(APPEND cxx-flags -Wall -Wextra -Werror -pedantic)
+    list(APPEND cxx-flags -std=c++2a -Wall -Wextra -Werror -pedantic)
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 ![](./example.png)
 
-`ulog` (uber log) is a lightweight and threadsafe logging library for C based programs. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. 
+`ulog` (uber log) is a lightweight and threadsafe logging library written in C, with support for C++. It features color coded output, with the ability to send logs to stdout and a file. File and line information indicating what fired the log is also included. It has INFO, WARN, ERROR, and DEBUG log levels, and is thoroughly tested with cmocka and valgrind. 
 
 If not using debug logging then any DEBUG level log calls are silently skipped. The logger is threadsafe in that multiple threads can't log at the same time. In practice there is very little lock contention and in all honesty you will probably never have to worry about it.
 
 In terms of memory usage, the only memory allocations conducted by this library are when initializing the logger. During actual logging there is no memory allocations whatsoever, as we use stack allocated variables. In practice logger initialization consumes arounds 7.4 KiB of memory, while regular logger usage general consumes no more than 3 -> 3.4 KiB of memory at any one time.
 
 **Please be aware that after calling `clear_thread_logger` or `clear_file_logger` using the logger results in undefined behavior, likely a panic causing the program to exit. Having one or more threads initiate a log invocation while concurrently calling `clear_thread_logger` or `clear_file_logger` results in undefined behavior. When clearing the logger you must be certain no other threads will attempt to use the logger.**
+
+# features
+
+* C/C++ support
+* lightweight (3 -> 3.4 KiB memory consumption)
+* threadsafe
+* color coded logs
+* stdout and file descriptor logging
+* file and line number that emitted the log included
 
 # why another logging library?
 
@@ -18,13 +27,13 @@ Interested in reading more about how `ulog` was born? [I published a blog post d
 
 # versioning
 
-The library follows semver as the versioning scheme. Additinoally the header files have `LOGGER_VERSION` and `COLORS_VERSION` macros which include the current release number. This is to help situations in which you may be using the library my copy and pasting the code into some other repository.
+The library follows the semver versioning scheme. Additionally a `version.h` header file has the current release version listed as a macro.
 
 # installation
 
 ## manual (broke)
 
-Copy and paste the `logger.h`, `colors.h`, `logger.c`, and `colors.c` files into whatever project you are working on. You will need to make sure that you have pthreads available to link with as the logger library has a pthreads dependency.
+Copy and paste the `logger.h`, `colors.h`, `version.h`, `logger.c`, and `colors.c` files into whatever project you are working on. You will need to make sure that you have pthreads available to link with as the logger library has a pthreads dependency.
 
 ## clib (woke)
 

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "ulog",
-  "version": "0.0.3-rc1",
+  "version": "0.0.3-rc2",
   "license": "agpl-v3",
   "description": "ulog (uber log) is a lightweight and threadsafe logger in C that provides color coded output, as well as the ability to send logs to a file",
   "repo": "bonedaddy/ulog",

--- a/clib.json
+++ b/clib.json
@@ -15,6 +15,7 @@
   "src": [
     "include/colors.h",
     "include/logger.h",
+    "include/version.h",
     "src/colors.c",
     "src/logger.c"
   ]

--- a/cmake/libraries/logger.cmake
+++ b/cmake/libraries/logger.cmake
@@ -1,6 +1,6 @@
 file(GLOB_RECURSE LOGGER_SOURCES
     ./include/*.h
-    ./src/*.c
+    ./src/*.c 
 )
 
 add_library(liblogger ${LOGGER_SOURCES})
@@ -8,8 +8,13 @@ target_compile_options(liblogger PRIVATE ${flags})
 target_link_libraries(liblogger pthread)
 
 
-add_executable(logger-test ./tests/logger_test.c)
-target_link_libraries(logger-test liblogger)
-target_link_libraries(logger-test cmocka)
-target_compile_options(logger-test PRIVATE ${flags})
-add_test(NAME LoggerTest COMMAND logger-test)
+add_executable(logger-test-c ./tests/logger_test.c)
+target_link_libraries(logger-test-c liblogger)
+target_link_libraries(logger-test-c cmocka)
+target_compile_options(logger-test-c PRIVATE ${flags})
+
+add_executable(logger-test-cpp ./tests/logger_test.cpp)
+target_link_libraries(logger-test-cpp liblogger)
+target_link_libraries(logger-test-cpp cmocka)
+target_compile_options(logger-test-cpp PRIVATE ${cxx-flags})
+add_test(NAME LoggerTest COMMAND logger-test-c)

--- a/include/colors.h
+++ b/include/colors.h
@@ -23,10 +23,6 @@
 
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define COLORS_VERSION '0.0.3-rc1'
 
 #define ANSI_COLOR_RED "\x1b[1;31m"
@@ -37,6 +33,10 @@ extern "C" {
 #define ANSI_COLOR_MAGENTA "\x1b[1;35m"
 #define ANSI_COLOR_CYAN "\x1b[1;36m"
 #define ANSI_COLOR_RESET "\x1b[1;0m"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*! @brief allows short-handed references to ANSI color schemes, and enables easier
  * color selection anytime you want to extend the available colors with an additional

--- a/include/colors.h
+++ b/include/colors.h
@@ -23,8 +23,6 @@
 
 #include <stdbool.h>
 
-#define COLORS_VERSION '0.0.3-rc1'
-
 #define ANSI_COLOR_RED "\x1b[1;31m"
 #define ANSI_COLOR_SOFT_RED "\x1b[1;38;5;210m"
 #define ANSI_COLOR_GREEN "\x1b[1;32m"

--- a/include/logger.h
+++ b/include/logger.h
@@ -31,10 +31,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define LOGGER_VERSION '0.0.3-rc1'
 
 /*!
@@ -131,6 +127,11 @@ extern "C" {
 #define LOGF_DEBUG(thl, fd, msg, ...) \
     thl->logf(thl, fd, LOG_LEVELS_DEBUG, __FILENAME__, __LINE__, msg, __VA_ARGS__);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /*! @struct base struct used by the thread_logger
  */
 struct thread_logger;
@@ -155,6 +156,17 @@ typedef enum {
  */
 typedef int (*mutex_fn)(pthread_mutex_t *mx);
 
+#ifdef __cplusplus
+/*! @typedef signature used by the thread_logger for log_fn calls
+ * @param thl pointer to an instance of thread_logger
+ * @param file_descriptor file descriptor to write log messages to, if 0 then only
+ * stdout is used
+ * @param message the actual message we want to log
+ * @param level the log level to use (effects color used)
+ */
+typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, const char *message,
+                       LOG_LEVELS level, const char *file, int line);
+#else
 /*! @typedef signature used by the thread_logger for log_fn calls
  * @param thl pointer to an instance of thread_logger
  * @param file_descriptor file descriptor to write log messages to, if 0 then only
@@ -164,7 +176,20 @@ typedef int (*mutex_fn)(pthread_mutex_t *mx);
  */
 typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, char *message,
                        LOG_LEVELS level, char *file, int line);
+#endif
 
+#ifdef __cplusplus
+/*! @typedef signatured used by the thread_logger for printf style log_fn calls
+ * @param thl pointer to an instance of thread_logger
+ * @param file_descriptor file descriptor to write log messages to, if 0 then only
+ * stdout is used
+ * @param level the log level to use (effects color used)
+ * @param message format string like `%sFOO%sBAR`
+ * @param ... values to supply to message
+ */
+typedef void (*log_fnf)(struct thread_logger *thl, int file_descriptor,
+                        LOG_LEVELS level, const char *file, int line, const char *message, ...);
+#else
 /*! @typedef signatured used by the thread_logger for printf style log_fn calls
  * @param thl pointer to an instance of thread_logger
  * @param file_descriptor file descriptor to write log messages to, if 0 then only
@@ -175,6 +200,7 @@ typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, char *mes
  */
 typedef void (*log_fnf)(struct thread_logger *thl, int file_descriptor,
                         LOG_LEVELS level, char *file, int line, char *message, ...);
+#endif
 
 /*! @typedef a thread safe logger
  * @brief guards all log calls with a mutex lock/unlock

--- a/include/logger.h
+++ b/include/logger.h
@@ -131,7 +131,6 @@
 extern "C" {
 #endif
 
-
 /*! @struct base struct used by the thread_logger
  */
 struct thread_logger;
@@ -164,8 +163,9 @@ typedef int (*mutex_fn)(pthread_mutex_t *mx);
  * @param message the actual message we want to log
  * @param level the log level to use (effects color used)
  */
-typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, const char *message,
-                       LOG_LEVELS level, const char *file, int line);
+typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor,
+                       const char *message, LOG_LEVELS level, const char *file,
+                       int line);
 #else
 /*! @typedef signature used by the thread_logger for log_fn calls
  * @param thl pointer to an instance of thread_logger
@@ -188,7 +188,8 @@ typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, char *mes
  * @param ... values to supply to message
  */
 typedef void (*log_fnf)(struct thread_logger *thl, int file_descriptor,
-                        LOG_LEVELS level, const char *file, int line, const char *message, ...);
+                        LOG_LEVELS level, const char *file, int line,
+                        const char *message, ...);
 #else
 /*! @typedef signatured used by the thread_logger for printf style log_fn calls
  * @param thl pointer to an instance of thread_logger
@@ -236,12 +237,21 @@ typedef struct file_logger {
  */
 thread_logger *new_thread_logger(bool with_debug);
 
+#ifdef __cplusplus
+/*! @brief returns a new file_logger
+ * Calls new_thread_logger internally
+ * @param output_file the file we will dump logs to. created if not exists and is
+ * appended to
+ */
+file_logger *new_file_logger(const char *output_file, bool with_debug);
+#else
 /*! @brief returns a new file_logger
  * Calls new_thread_logger internally
  * @param output_file the file we will dump logs to. created if not exists and is
  * appended to
  */
 file_logger *new_file_logger(char *output_file, bool with_debug);
+#endif
 
 /*! @brief free resources for the threaded logger
  * @param thl the thread_logger instance to free memory for

--- a/include/logger.h
+++ b/include/logger.h
@@ -31,8 +31,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#define LOGGER_VERSION '0.0.3-rc1'
-
 /*!
  * @brief strips leading path from __FILE__
  */

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,13 @@
+/*!
+ * @file version.h
+ * @author Bonedaddy
+ * @brief provides release version information as a macro
+ * @details dedicated file containing the current version of ulog as a macro
+ * @details largely used to make it easy to verify what version of the library you
+ * are using
+ */
+
+/*!
+ * @brief denotes the current version of the ulog library
+ */
+#define ULOG_VERSION "v0.0.3-rc1"

--- a/include/version.h
+++ b/include/version.h
@@ -7,6 +7,8 @@
  * are using
  */
 
+#pragma once
+
 /*!
  * @brief denotes the current version of the ulog library
  */

--- a/include/version.h
+++ b/include/version.h
@@ -12,4 +12,4 @@
 /*!
  * @brief denotes the current version of the ulog library
  */
-#define ULOG_VERSION "v0.0.3-rc1"
+#define ULOG_VERSION "v0.0.3-rc2"

--- a/src/logger.c
+++ b/src/logger.c
@@ -173,8 +173,6 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
 
     get_time_string(time_str, 76);
 
-    printf("time debug: %s\n", time_str);
-
     char location_info[strlen(file) + sizeof(line) + 4];
     memset(location_info, 0, sizeof(location_info));
 

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -1,0 +1,15 @@
+#include "logger.h"
+
+int main(void) {
+    thread_logger *thl = new_thread_logger(true);
+    LOG_INFO(thl, 0, "this is an info log");
+    LOG_WARN(thl, 0, "this is a warn log");
+    LOG_ERROR(thl, 0, "this is an error log");
+    LOG_DEBUG(thl, 0, "this is a debug log");
+    LOGF_INFO(thl, 0, "this is a %s style info log", "printf");
+    LOGF_WARN(thl, 0, "this is a %s style warn log", "printf");
+    LOGF_ERROR(thl, 0, "this is a %s style error log", "printf");
+    LOGF_DEBUG(thl, 0, "this is a %s style debug log", "printf");
+
+    clear_thread_logger(thl); 
+}

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -1,6 +1,30 @@
+#include <string.h>
+#include <stdio.h>
 #include "logger.h"
 
+typedef struct args {
+    COLORS test_color;
+    const char *want_ansi;
+} args_t;
+typedef struct test {
+    const char *name;
+    args_t args;
+} test_t;
+
+
+void validate_test_args(test testdata) {
+    //   printf("%s\n", format_colored(testdata.args.test_color, testdata.name));
+    char *scheme = get_ansi_color_scheme(testdata.args.test_color);
+    if (strcmp(scheme, testdata.args.want_ansi) == 0) {
+
+        printf("%stest %s passed\n", scheme, testdata.name);
+        return;
+    }
+    printf("test %s failed\n", testdata.name);
+}
+
 int main(void) {
+    // thread logger tests
     thread_logger *thl = new_thread_logger(true);
     LOG_INFO(thl, 0, "this is an info log");
     LOG_WARN(thl, 0, "this is a warn log");
@@ -10,6 +34,81 @@ int main(void) {
     LOGF_WARN(thl, 0, "this is a %s style warn log", "printf");
     LOGF_ERROR(thl, 0, "this is a %s style error log", "printf");
     LOGF_DEBUG(thl, 0, "this is a %s style debug log", "printf");
+    clear_thread_logger(thl);
+    
+    // file logger tests
+    file_logger *fhl = new_file_logger("testfile.log", true);
+    LOG_INFO(fhl->thl, fhl->fd, "this is an info log");
+    LOG_WARN(fhl->thl, fhl->fd,"this is a warn log");
+    LOG_ERROR(fhl->thl, fhl->fd, "this is an error log");
+    LOG_DEBUG(fhl->thl, fhl->fd, "this is a debug log");
+    LOGF_INFO(fhl->thl, fhl->fd, "this is a %s style info log", "printf");
+    LOGF_WARN(fhl->thl, fhl->fd, "this is a %s style warn log", "printf");
+    LOGF_ERROR(fhl->thl, fhl->fd, "this is a %s style error log", "printf");
+    LOGF_DEBUG(fhl->thl, fhl->fd, "this is a %s style debug log", "printf");
+    LOG_INFO(fhl->thl, 0, "this will only log to stdout");
+    LOGF_INFO(fhl->thl, 0, "this will only log to %s", "stdout");
+    clear_file_logger(fhl);
 
-    clear_thread_logger(thl); 
+    test_t tests[8] = {
+        {
+            .name = "red", 
+            .args = {
+                .test_color = COLORS_RED,
+                .want_ansi = ANSI_COLOR_RED,
+            },
+        },
+        {
+            .name = "soft_red",
+            .args = {
+                .test_color = COLORS_SOFT_RED,
+                .want_ansi = ANSI_COLOR_SOFT_RED,
+            },
+        },
+        {
+            .name = "green", 
+            .args = {
+                .test_color = COLORS_GREEN,
+                .want_ansi = ANSI_COLOR_GREEN,
+            },
+        },
+        {
+            .name = "yellow", 
+            .args = {
+                .test_color = COLORS_YELLOW,
+                .want_ansi = ANSI_COLOR_YELLOW,
+            },
+        },
+        {
+            .name = "blue", 
+            .args = {
+                .test_color = COLORS_BLUE,
+                .want_ansi = ANSI_COLOR_BLUE,
+            },
+        },
+        {
+            .name = "magenta", 
+            .args = {
+                .test_color = COLORS_MAGENTA,
+                .want_ansi = ANSI_COLOR_MAGENTA,
+            },
+        },
+        {
+            .name = "cyan", 
+            .args = {
+                .test_color = COLORS_CYAN,
+                .want_ansi = ANSI_COLOR_CYAN,
+            },
+        },
+        {
+            .name = "reset", 
+            .args = {
+                .test_color = COLORS_RESET,
+                .want_ansi = ANSI_COLOR_RESET,
+            },
+        },
+    };
+    for (int i = 0; i < 7; i++) {
+        validate_test_args(tests[i]);
+    }
 }


### PR DESCRIPTION
* Declare the `extern "C" {` start after macros are declared
  * This appeared to cause an issue with macros in C++ handling strings as `const char` rather than `char`
* Change function parameter signature for C++ when compiling for C++
* Update cmake to include CXX as project language
* Add separate test binary for C++