### PR TITLE
Removed Invalid Dependency

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -10,7 +10,6 @@
     "threadsafe"
   ],
   "dependencies": {
-    "pthreads": ""
   },
   "src": [
     "include/colors.h",


### PR DESCRIPTION
This dependency field causes the clib install to fail. 
Might I suggest adding the pthreads requirement callout to the clib section as well.

This pull request includes a small change to the `clib.json` file. The change removes the `pthreads` dependency from the list of dependencies.

* [`clib.json`](diffhunk://#diff-00771458a4d376080b13d36a07885d1cc4397286e823d83021d3deff1a860602L13): Removed the `pthreads` dependency.